### PR TITLE
Bulk discount create

### DIFF
--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -6,4 +6,30 @@ class MerchantBulkDiscountsController < ApplicationController
   def show
     @discount = BulkDiscount.find(params[:discount_id])
   end
+
+  def new
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def create
+    @merchant = Merchant.find(params[:id])
+    discount = @merchant.bulk_discounts.new(discount_params)
+
+    if params[:quantity_threshold].empty? || params[:discount_percent].empty?
+      flash[:notice] = "fields can not be empty"
+      redirect_to "/merchants/#{@merchant.id}/bulk_discounts/new"
+    elsif params[:discount_percent].to_i > 100 || params[:discount_percent].to_i < 1
+      flash[:notice] = "discount must be between 1-100%"
+      redirect_to "/merchants/#{@merchant.id}/bulk_discounts/new"
+    else
+      discount.save
+      redirect_to "/merchants/#{@merchant.id}/bulk_discounts"
+    end
+  end
+
+  private
+
+  def discount_params
+    params.permit(:discount_percent, :quantity_threshold)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <% flash.each do |type, message| %>
-      <p><%= message %></p>
+      <p><%= "#{type.capitalize}: #{message}" %></p>
     <% end %>
     <%= yield %>
   </body>

--- a/app/views/merchant_bulk_discounts/index.html.erb
+++ b/app/views/merchant_bulk_discounts/index.html.erb
@@ -1,5 +1,5 @@
-<h1><%= @merchant.name %>'s bulk discounts</h1>
-
+<h1><%= @merchant.name %>'s bulk discounts</h1><br>
+<%= link_to 'New Discount', "/merchants/#{@merchant.id}/bulk_discounts/new" %><br>
 <% @merchant.bulk_discounts.each do |discount| %>
   <div id="discount-<%= discount.id %>">
     <ul>

--- a/app/views/merchant_bulk_discounts/new.html.erb
+++ b/app/views/merchant_bulk_discounts/new.html.erb
@@ -1,0 +1,11 @@
+<h1>Create a new merchant</h1>
+
+<%= form_with url: "/merchants/#{@merchant.id}/bulk_discounts", local: true do |form| %>
+  <%= form.label :quantity_threshold %>
+  <%= form.number_field :quantity_threshold %>
+
+  <%= form.label :discount_percent %>
+  <%= form.number_field :discount_percent %>
+
+  <%= form.submit 'Submit' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get 'merchants/:id/dashboard', to: 'merchants#show'
 
   get '/merchants/:id/bulk_discounts', to: 'merchant_bulk_discounts#index'
+  post '/merchants/:id/bulk_discounts', to: 'merchant_bulk_discounts#create'
+  get '/merchants/:id/bulk_discounts/new', to: 'merchant_bulk_discounts#new'
   get '/merchants/:id/bulk_discounts/:discount_id', to: 'merchant_bulk_discounts#show'
 
   get 'merchants/:id/invoices', to: 'merchant_invoices#index'

--- a/spec/features/merchant_bulk_discounts/index_spec.rb
+++ b/spec/features/merchant_bulk_discounts/index_spec.rb
@@ -12,41 +12,49 @@ RSpec.describe 'bulk discounts index page' do
     visit "/merchants/#{@merchant_1.id}/bulk_discounts"
   end
 
-  context 'links' do
+  context 'CRUD links' do
     it 'each bulk discount should be a link to its show page' do
       click_link("Discount #{@discount_1.id}")
 
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/#{@discount_1.id}")
     end
+
+    it 'has a link to create a new discount' do
+      click_link 'New Discount'
+
+      expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discount/new")
+    end
   end
 
-  it 'shows all discounts for a given merchant' do
-    expect(page).to have_css("#discount-#{@discount_1.id}")
-    expect(page).to have_css("#discount-#{@discount_1a.id}")
-    expect(page).to_not have_css("#discount-#{@discount_2.id}")
-  end
-
-  it 'each discount has its quantity and discount percentage nearby' do
-    within "#discount-#{@discount_1.id}" do
-      expect(page).to have_content("Discount #{@discount_1.id}")
-      expect(page).to_not have_content("Discount #{@discount_1a.id}")
-
-      expect(page).to have_content("Quantity threshold: 10")
-      expect(page).to have_content("Discount percentage: 25")
-
-      expect(page).to_not have_content("Quantity threshold: 15")
-      expect(page).to_not have_content("Discount percentage: 30")
+  context 'discounts' do
+    it 'shows all discounts for a given merchant' do
+      expect(page).to have_css("#discount-#{@discount_1.id}")
+      expect(page).to have_css("#discount-#{@discount_1a.id}")
+      expect(page).to_not have_css("#discount-#{@discount_2.id}")
     end
 
-    within "#discount-#{@discount_1a.id}" do
-      expect(page).to have_content("Discount #{@discount_1a.id}")
-      expect(page).to_not have_content("Discount #{@discount_1.id}")
+    it 'each discount has its quantity and discount percentage nearby' do
+      within "#discount-#{@discount_1.id}" do
+        expect(page).to have_content("Discount #{@discount_1.id}")
+        expect(page).to_not have_content("Discount #{@discount_1a.id}")
 
-      expect(page).to have_content("Quantity threshold: 15")
-      expect(page).to have_content("Discount percentage: 30")
+        expect(page).to have_content("Quantity threshold: 10")
+        expect(page).to have_content("Discount percentage: 25")
 
-      expect(page).to_not have_content("Quantity threshold: 10")
-      expect(page).to_not have_content("Discount percentage: 25")
+        expect(page).to_not have_content("Quantity threshold: 15")
+        expect(page).to_not have_content("Discount percentage: 30")
+      end
+
+      within "#discount-#{@discount_1a.id}" do
+        expect(page).to have_content("Discount #{@discount_1a.id}")
+        expect(page).to_not have_content("Discount #{@discount_1.id}")
+
+        expect(page).to have_content("Quantity threshold: 15")
+        expect(page).to have_content("Discount percentage: 30")
+
+        expect(page).to_not have_content("Quantity threshold: 10")
+        expect(page).to_not have_content("Discount percentage: 25")
+      end
     end
   end
 end

--- a/spec/features/merchant_bulk_discounts/index_spec.rb
+++ b/spec/features/merchant_bulk_discounts/index_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'bulk discounts index page' do
     it 'has a link to create a new discount' do
       click_link 'New Discount'
 
-      expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discount/new")
+      expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/new")
     end
   end
 

--- a/spec/features/merchant_bulk_discounts/new_spec.rb
+++ b/spec/features/merchant_bulk_discounts/new_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'new discount form' do
 
   it 'can create a new discount' do
     expect(page).to_not have_content('Quantity threshold: 25')
-    expect(page).to_not have_content('Discount percent: 50')
+    expect(page).to_not have_content('Discount percentage: 50')
     click_link 'New Discount'
 
     fill_in :quantity_threshold, with: 25
@@ -22,7 +22,7 @@ RSpec.describe 'new discount form' do
 
     expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts")
     expect(page).to have_content('Quantity threshold: 25')
-    expect(page).to have_content('Discount percent: 50')
+    expect(page).to have_content('Discount percentage: 50')
   end
 
   context 'takes valid data only' do
@@ -40,10 +40,11 @@ RSpec.describe 'new discount form' do
       click_link 'New Discount'
 
       fill_in :discount_percent, with: 101
+      fill_in :quantity_threshold, with: 50
       click_button 'Submit'
-
+      
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/new")
-      expect(page).to have_content("Notice: discount can not be over 100%")
+      expect(page).to have_content("Notice: discount must be between 1-100%")
     end
   end
 end

--- a/spec/features/merchant_bulk_discounts/new_spec.rb
+++ b/spec/features/merchant_bulk_discounts/new_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+# Merchant Bulk Discount Create
+#
+# As a merchant
+# When I visit my bulk discounts index
+# Then I see a link to create a new discount
+# When I click this link
+# Then I am taken to a new page where I see a form to add a new bulk discount
+# When I fill in the form with valid data
+# Then I am redirected back to the bulk discount index
+# And I see my new bulk discount listed
+RSpec.describe 'new discount form' do
+  it 'can create a new discount' do
+    merchant_1 = Merchant.create!(name: 'Brylan')
+    discount_1 = merchant_1.bulk_discounts.create!(quantity_threshold: 10, discount_percent: 25)
+    discount_1a = merchant_1.bulk_discounts.create!(quantity_threshold: 15, discount_percent: 30)
+
+    merchant_2 = Merchant.create!(name: 'Jeffrey')
+    discount_2 = merchant_2.bulk_discounts.create!(quantity_threshold: 20, discount_percent: 5)
+
+    visit "/merchants/#{merchant_1.id}/bulk_discounts"
+
+    expect(page).to_not have_content('Quantity threshold: 25')
+    expect(page).to_not have_content('Discount percent: 50')
+    click_link 'New Discount'
+
+    fill_in :quantity_threshold, with: 25
+    fill_in :discount_percent, with: 50
+    click_button 'Submit'
+
+    expect(current_path).to eq("/merchants/#{merchant_1.id}/bulk_discounts")
+    expect(page).to have_content('Quantity threshold: 25')
+    expect(page).to have_content('Discount percent: 50')
+  end
+end

--- a/spec/features/merchant_bulk_discounts/new_spec.rb
+++ b/spec/features/merchant_bulk_discounts/new_spec.rb
@@ -1,25 +1,17 @@
 require 'rails_helper'
-# Merchant Bulk Discount Create
-#
-# As a merchant
-# When I visit my bulk discounts index
-# Then I see a link to create a new discount
-# When I click this link
-# Then I am taken to a new page where I see a form to add a new bulk discount
-# When I fill in the form with valid data
-# Then I am redirected back to the bulk discount index
-# And I see my new bulk discount listed
 RSpec.describe 'new discount form' do
+  before :each do
+    @merchant_1 = Merchant.create!(name: 'Brylan')
+    @discount_1 = @merchant_1.bulk_discounts.create!(quantity_threshold: 10, discount_percent: 25)
+    @discount_1a = @merchant_1.bulk_discounts.create!(quantity_threshold: 15, discount_percent: 30)
+
+    @merchant_2 = Merchant.create!(name: 'Jeffrey')
+    @discount_2 = @merchant_2.bulk_discounts.create!(quantity_threshold: 20, discount_percent: 5)
+
+    visit "/merchants/#{@merchant_1.id}/bulk_discounts"
+  end
+
   it 'can create a new discount' do
-    merchant_1 = Merchant.create!(name: 'Brylan')
-    discount_1 = merchant_1.bulk_discounts.create!(quantity_threshold: 10, discount_percent: 25)
-    discount_1a = merchant_1.bulk_discounts.create!(quantity_threshold: 15, discount_percent: 30)
-
-    merchant_2 = Merchant.create!(name: 'Jeffrey')
-    discount_2 = merchant_2.bulk_discounts.create!(quantity_threshold: 20, discount_percent: 5)
-
-    visit "/merchants/#{merchant_1.id}/bulk_discounts"
-
     expect(page).to_not have_content('Quantity threshold: 25')
     expect(page).to_not have_content('Discount percent: 50')
     click_link 'New Discount'
@@ -28,8 +20,30 @@ RSpec.describe 'new discount form' do
     fill_in :discount_percent, with: 50
     click_button 'Submit'
 
-    expect(current_path).to eq("/merchants/#{merchant_1.id}/bulk_discounts")
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts")
     expect(page).to have_content('Quantity threshold: 25')
     expect(page).to have_content('Discount percent: 50')
+  end
+
+  context 'takes valid data only' do
+    it 'fields can not be empty' do
+      click_link 'New Discount'
+
+      fill_in :discount_percent, with: 50
+      click_button 'Submit'
+
+      expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/new")
+      expect(page).to have_content("Notice: fields can not be empty")
+    end
+
+    it 'discount percent can not be over 100' do
+      click_link 'New Discount'
+
+      fill_in :discount_percent, with: 101
+      click_button 'Submit'
+
+      expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/new")
+      expect(page).to have_content("Notice: discount can not be over 100%")
+    end
   end
 end


### PR DESCRIPTION
- Merchant bulk discount index page has link to create a new discount
- If fields are empty or discount percent is not within 1-100%:
   -  page shows an error message and prompts user to refill the new form