### PR TITLE
Admin index refactor

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,5 @@
 class AdminController < ApplicationController
   def index
-    @incomplete_invoices = InvoiceItem.incomplete_invoices
-    @merchant = Merchant.first
+    @incomplete_invoices = Invoice.incomplete_invoices
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -17,4 +17,10 @@ class Invoice < ApplicationRecord
     invoice_items.sum("unit_price * quantity")
   end
 
+  def self.incomplete_invoices
+    joins(:invoice_items)
+    .where("invoice_items.status != 2")
+    .order(:created_at)
+    .distinct
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -13,10 +13,4 @@ class InvoiceItem < ApplicationRecord
   def self.items_total_revenue
     sum('quantity * unit_price')
   end
-
-  def self.incomplete_invoices
-    InvoiceItem.joins(:invoice)
-               .where.not(status: 'shipped')
-               .order("invoices.created_at")
-  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -7,22 +7,11 @@
 <h2>Incomplete Invoices:</h2>
 
 <div id="incomplete_invoices">
-  <% @incomplete_invoices.each do |invoice_item| %>
-      <p><%= link_to "#{invoice_item.invoice_id}", "admin/invoices/#{invoice_item.invoice_id}" %>
-        Created at: <%= invoice_item.invoice.created_at.strftime("%A, %B %d, %Y") %>
+  <% @incomplete_invoices.each do |invoice| %>
+      <p><%= link_to "#{invoice.id}", "admin/invoices/#{invoice.id}" %>
+        Created at: <%= invoice.created_at.strftime("%A, %B %d, %Y") %>
       </p>
    <% end %>
 </div>
 
 <br>
-
-<div id="statistics">
-  <h3>Top 5 Customers: </h3>
-  <% if @merchant != nil %>
-    <% @merchant.top_five_customers.each do |customer| %>
-      <div id="customer-<%= customer.id %>">
-        <h4>Name: <%= customer.first_name %> <%= customer.last_name %></h4>
-        <p>Successful Transactions: <%= customer.successful_transactions.count %></p>
-      </div>
-    <% end %>
-  <% end %>

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Admin Dashboard' do
       invoice_4 = customer_1.invoices.create!(status: 'completed')
       invoice_5 = customer_1.invoices.create!(status: 'completed')
       item_1.invoice_items.create!(invoice_id: invoice_1.id, quantity: 3, unit_price: 400, status: 'packaged')
-      item_2.invoice_items.create!(invoice_id: invoice_2.id, quantity: 5, unit_price: 400, status: 'pending')
+      item_2.invoice_items.create!(invoice_id: invoice_1.id, quantity: 5, unit_price: 400, status: 'pending')
       item_3.invoice_items.create!(invoice_id: invoice_3.id, quantity: 5, unit_price: 400, status: 'packaged')
       item_4.invoice_items.create!(invoice_id: invoice_4.id, quantity: 5, unit_price: 400, status: 'packaged')
       item_5.invoice_items.create!(invoice_id: invoice_5.id, quantity: 5, unit_price: 400, status: 'shipped')
@@ -104,7 +104,7 @@ RSpec.describe 'Admin Dashboard' do
       expect(page).to have_content("Incomplete Invoices")
 
       within '#incomplete_invoices' do
-        expect(page).to have_link("#{invoice_1.id}")
+        expect(page).to have_link("#{invoice_1.id}", count: 1)
         expect(page).to have_link("#{invoice_2.id}")
         expect(page).to have_link("#{invoice_3.id}")
         expect(page).to have_link("#{invoice_4.id}")

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe 'Admin Dashboard' do
       invoice_5 = customer_1.invoices.create!(status: 'completed')
       item_1.invoice_items.create!(invoice_id: invoice_1.id, quantity: 3, unit_price: 400, status: 'packaged')
       item_2.invoice_items.create!(invoice_id: invoice_1.id, quantity: 5, unit_price: 400, status: 'pending')
+      item_2.invoice_items.create!(invoice_id: invoice_2.id, quantity: 5, unit_price: 400, status: 'pending')
       item_3.invoice_items.create!(invoice_id: invoice_3.id, quantity: 5, unit_price: 400, status: 'packaged')
       item_4.invoice_items.create!(invoice_id: invoice_4.id, quantity: 5, unit_price: 400, status: 'packaged')
       item_5.invoice_items.create!(invoice_id: invoice_5.id, quantity: 5, unit_price: 400, status: 'shipped')
@@ -147,38 +148,6 @@ RSpec.describe 'Admin Dashboard' do
         expect(invoice_4_date).to appear_before(invoice_3_date)
         expect(invoice_3_date).to appear_before(invoice_1_date)
         expect(page).to_not have_content(invoice_5_date)
-      end
-    end
-
-    it 'I see the names of the top 5 customers who have the most successful transactions and displays the number of successful transactions they have conducted' do
-      within '#statistics' do
-        expect("Joey Ondricka").to appear_before("Osinski Cecelia")
-        expect("Osinski Cecelia").to appear_before("Toy Mariah")
-        expect("Toy Mariah").to appear_before("Joy Braun")
-        expect("Joy Braun").to appear_before("Mark Brains")
-        expect("Mark Brains").to_not appear_before("Joy Braun")
-      end
-    end
-
-    it 'displays the number of successful transactions next to each customer' do
-      within "#customer-#{@customer_1.id}" do
-        expect(page).to have_content('Successful Transactions: 6')
-      end
-
-      within "#customer-#{@customer_2.id}" do
-        expect(page).to have_content('Successful Transactions: 5')
-      end
-
-      within "#customer-#{@customer_3.id}" do
-        expect(page).to have_content('Successful Transactions: 4')
-      end
-
-      within "#customer-#{@customer_4.id}" do
-        expect(page).to have_content('Successful Transactions: 3')
-      end
-
-      within "#customer-#{@customer_5.id}" do
-        expect(page).to have_content('Successful Transactions: 2')
       end
     end
   end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -61,9 +61,5 @@ RSpec.describe InvoiceItem do
     it 'can calculate the items total revenue' do
       expect(InvoiceItem.items_total_revenue).to eq(119088)
     end
-
-    it 'can return invoices with items that have not shipped' do
-      expect(InvoiceItem.incomplete_invoices.count).to eq(1)
-    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Invoice do
     end
 
     it '.incomplete_invoices can return invoices with items that have not shipped' do
-      expect(Invoice.incomplete_invoices).to be_a(Array)
       expect(Invoice.incomplete_invoices).to eq([@invoice, @invoice_2])
       expect(Invoice.incomplete_invoices.count).to eq(2)
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe Invoice do
     @item_1 = @merchant.items.create!(name: 'Bottle', unit_price: 100, description: 'H20')
     @item_2 = @merchant.items.create!(name: 'Can', unit_price: 500, description: 'Soda')
 
-    @customer = Customer.create!(first_name: "Billy", last_name: "Jonson",
-                                 created_at: Time.parse('2012-03-27 14:54:09 UTC'),
-                                 updated_at: Time.parse('2012-03-27 14:54:09 UTC'))
-
-    @invoice = @customer.invoices.create!(status: "in progress",
-                                          created_at: Time.parse('2012-03-25 09:54:09 UTC'),
-                                          updated_at: Time.parse('2012-03-25 09:54:09 UTC'))
+    @customer = Customer.create!(first_name: "Billy", last_name: "Jonson")
+    @invoice = @customer.invoices.create!(status: "in progress")
+    @invoice_2 = @customer.invoices.create!(status: "in progress")
+    @invoice_3 = @customer.invoices.create!(status: "completed")
 
     @invoice_item_1 = @invoice.invoice_items.create!(item_id: @item_1.id, quantity: 8, unit_price: 100, status: 'shipped')
-    @invoice_item_2 = @invoice.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'packaged')
+    @invoice_item_1a = @invoice.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'packaged')
+    @invoice_item_2 = @invoice_2.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'packaged')
+    @invoice_item_3 = @invoice_3.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'shipped')
   end
 
   context 'readable attributes' do
@@ -38,7 +37,10 @@ RSpec.describe Invoice do
   context 'instance methods' do
     it '.get_invoice_item(id) returns a specific invoice item' do
       expect(@invoice.get_invoice_item(@item_1.id)).to eq(@invoice_item_1)
-      expect(@invoice.get_invoice_item(@item_2.id)).to eq(@invoice_item_2)
+      expect(@invoice.get_invoice_item(@item_1.id)).to be_a(InvoiceItem)
+
+      expect(@invoice.get_invoice_item(@item_2.id)).to eq(@invoice_item_1a)
+      expect(@invoice.get_invoice_item(@item_2.id)).to be_a(InvoiceItem)
     end
 
     it '.total_revenue returns the sum of all item costs' do
@@ -52,6 +54,14 @@ RSpec.describe Invoice do
       item_2.invoice_items.create!(invoice_id: invoice.id, quantity: 3, unit_price: 4, status: 2)
       item_3.invoice_items.create!(invoice_id: invoice.id, quantity: 3, unit_price: 4, status: 2)
       expect(invoice.total_revenue).to eq(36)
+    end
+
+    it '.incomplete_invoices can return invoices with items that have not shipped' do
+      expect(Invoice.incomplete_invoices).to be_a(Array)
+      expect(Invoice.incomplete_invoices).to eq([@invoice, @invoice_2])
+      expect(Invoice.incomplete_invoices.count).to eq(2)
+
+      expect(Invoice.incomplete_invoices).to_not include(@invoice_3)
     end
   end
 end


### PR DESCRIPTION
The admin index had lots of repeated data - found out it was because the `incomplete_invoices` method was under the `InvoiceItem` class, causing multiple of the same invoice to be printed on the page. 

Moved that class method over to Invoice.rb, and now the admin dashboard has unique invoices listed 👍