### PR TITLE
Fix merchant invoice show

### DIFF
--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -19,7 +19,7 @@
 
 <h2>Items ordered:</h2>
 
-<% @invoice.invoice_items.each do |invoice_item| %>
+<% @invoice.get_items_from_merchant(params[:merchant_id]).each do |invoice_item| %>
   <div id="item-<%= invoice_item.item_id %>">
     <h4><%= invoice_item.item.name %></h4>
     <ul>
@@ -49,8 +49,8 @@
 <% end %>
 
 <div id="revenue">
-  <h2>Total Revenue: $<%= @invoice.total_revenue.to_s.insert(-3,".") %> </h2>
+  <h2>Total Revenue: $<%= @invoice.revenue_for(params[:merchant_id]).to_s.insert(-3,".") %> </h2>
   <% unless @invoice.orders_that_can_be_discounted.empty? %>
-    <h2>Discounted Revenue: $<%= @invoice.total_discounted_revenue.to_s.insert(-3,".") %></h2>
+    <h2>Discounted Revenue: $<%= @invoice.discounted_revenue_for(params[:merchant_id]).to_s.insert(-3,".") %></h2>
   <% end %>
 </div>

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'merchant invoice show page' do
         expect(page).to have_content("Total Revenue: $33.00")
         expect(page).to_not have_content("Total Revenue: $53.00")
         expect(page).to_not have_content("Total Revenue: $29.70")
-        expect(page).to have_content("Discounted Revenue: $29.00")
+        expect(page).to have_content("Discounted Revenue: $29.70")
       end
 
       visit "/merchants/#{merchant_2.id}/invoices/#{invoice_1.id}"

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'merchant invoice show page' do
     end
 
     it "displays the total revenue for the merchant's items on the invoice" do
-      expect(page).to have_content("Total Revenue: $38.00")
+      expect(page).to have_content("Total Revenue: $33.00")
       expect(page).to_not have_content("Total Revenue: $58.00")
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe Invoice do
       expect(@invoice_3.get_items_from_merchant(@merchant_2.id)).to be_empty
     end
 
+    it '.revenue_for(merchant_id) returns the revenue made by a given merchant' do
+      expect(@invoice.revenue_for(@merchant.id)).to eq(3300)
+      expect(@invoice.revenue_for(@merchant_2.id)).to eq(2000)
+
+      expect(@invoice.revenue_for(@merchant.id)).to_not eq(5300)
+      expect(@invoice.revenue_for(@merchant_2.id)).to_not eq(3300)
+    end
+
     it '.total_revenue returns the sum of all item costs' do
       merchant = Merchant.create!(name: 'Brylan')
       item_1 = merchant.items.create!(name: 'Bottle', unit_price: 10, description: 'H20')

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe Invoice do
       expect(@invoice.revenue_for(@merchant_2.id)).to_not eq(3300)
     end
 
-
     it '.total_revenue returns the sum of all item costs' do
       merchant = Merchant.create!(name: 'Brylan')
       item_1 = merchant.items.create!(name: 'Bottle', unit_price: 10, description: 'H20')
@@ -129,6 +128,16 @@ RSpec.describe Invoice do
 
       expect(invoice_item_1b.best_deal).to eq(10)
       expect(invoice_item_1b.best_deal).to_not eq(8)
+    end
+
+    it '.discounted_revenue_for(merchant_id) just returns revenue_for(merchant_id) if no discounts are applied' do
+      expect(@invoice_2.discounted_revenue_for(@merchant_2.id)).to eq(@invoice_2.revenue_for(@merchant_2.id))
+      expect(@invoice_2.discounted_revenue_for(@merchant.id)).to eq(0)
+    end
+
+    it '.discounted_revenue_for(merchant_id) returns the discounted revenue for a given merchant' do
+      expect(@invoice_1.discounted_revenue_for(@merchant.id)).to eq(2970)
+      expect(@invoice_1.discounted_revenue_for(@merchant.id)).to_not eq(3300)
     end
 
     it '.total_discounted_revenue just returns total_revenue if no discounts are applied' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Invoice do
       @item_1 = @merchant.items.create!(name: 'Bottle', unit_price: 100, description: 'H20')
       @item_2 = @merchant.items.create!(name: 'Can', unit_price: 500, description: 'Soda')
 
+      @merchant_2 = Merchant.create!(name: 'Jilly Bonson')
+      @item_3 = @merchant_2.items.create!(name: 'Juice Box', unit_price: 300, description: 'Apple Juice')
+
       @customer = Customer.create!(first_name: "Billy", last_name: "Jonson")
       @invoice = @customer.invoices.create!(status: "in progress")
       @invoice_2 = @customer.invoices.create!(status: "in progress")
@@ -27,6 +30,7 @@ RSpec.describe Invoice do
 
       @invoice_item_1 = @invoice.invoice_items.create!(item_id: @item_1.id, quantity: 8, unit_price: 100, status: 'shipped')
       @invoice_item_1a = @invoice.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'packaged')
+      @invoice_item_1b = @invoice.invoice_items.create!(item_id: @item_3.id, quantity: 5, unit_price: 500, status: 'packaged')
       @invoice_item_2 = @invoice_2.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'packaged')
       @invoice_item_3 = @invoice_3.invoice_items.create!(item_id: @item_2.id, quantity: 5, unit_price: 500, status: 'shipped')
     end
@@ -48,6 +52,16 @@ RSpec.describe Invoice do
       expect(Invoice.incomplete_invoices.count).to eq(2)
 
       expect(Invoice.incomplete_invoices).to_not include(@invoice_3)
+    end
+
+    it '.get_items_from_merchant(merchant_id) returns all invoice items with the given merchant_id' do
+      expect(@invoice.get_items_from_merchant(@merchant.id)).to include(@invoice_item_1, @invoice_item_1a)
+      expect(@invoice.get_items_from_merchant(@merchant_2.id)).to include(@invoice_item_1b)
+
+      expect(@invoice.get_items_from_merchant(@merchant.id)).to_not include(@invoice_item_1b)
+      expect(@invoice.get_items_from_merchant(@merchant_2.id)).to_not include(@invoice_item_1, @invoice_item_1a)
+      expect(@invoice_2.get_items_from_merchant(@merchant_2.id)).to be_empty
+      expect(@invoice_3.get_items_from_merchant(@merchant_2.id)).to be_empty
     end
 
     it '.total_revenue returns the sum of all item costs' do
@@ -116,7 +130,7 @@ RSpec.describe Invoice do
     it '.total_discounted_revenue returns total revenue minus applied discounts' do
       expect(@invoice_1.total_discounted_revenue).to eq(6810)
       expect(@invoice_1.total_discounted_revenue).to_not eq(6650)
-      expect(@invoice_1.total_discounted_revenue).to_not eq(7300) 
+      expect(@invoice_1.total_discounted_revenue).to_not eq(7300)
     end
   end
 end


### PR DESCRIPTION
The merchant invoice show page was displaying data on the entire invoice, when it should have only been displaying data on the current merchant's items. Fixed it by adding a couple instance methods to invoice.rb: 

- `.get_items_from_merchant(merchant_id)`: helper method that grabs all invoice items on the invoice who's item belongs to the merchant who has the given merchant_id
- `orders_that_can_be_discounted_for(merchant_id`: helper method that only grabs the given merchant's invoice_items that qualify for a discount
- `.revenue_for(merchant_id)`: calls `get_items_from_merchant(merchant_id)` and calculates total revenue without discounts
- `discounted_revenue_for(merchant_id)`: calculates the discounted revenue for a given merchant by adding up discounted revenue of each item that qualifies, and adds that to the total revenue of the items that don't.