### PR TITLE
Refactor invoice show

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -20,6 +20,12 @@ class Invoice < ApplicationRecord
                  .sum { |invoice_item| invoice_item.total_revenue }
   end
 
+  def discounted_revenue_for(merchant)
+    invoice_items.joins(item: :merchant)
+                 .where(merchants: {id: merchant})
+                 .sum { |invoice_item| invoice_item.discounted_revenue }
+  end
+
   def total_invoice_revenue
     invoice_items.sum { |invoice_item| invoice_item.total_revenue }.to_i
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -14,6 +14,12 @@ class Invoice < ApplicationRecord
     invoice_items.find_by(item_id: item_id)
   end
 
+  def total_revenue_for(merchant)
+    invoice_items.joins(item: :merchant)
+                 .where(merchants: {id: merchant})
+                 .sum { |invoice_item| invoice_item.total_revenue }
+  end
+
   def total_invoice_revenue
     invoice_items.sum { |invoice_item| invoice_item.total_revenue }.to_i
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -23,7 +23,7 @@ class Invoice < ApplicationRecord
   def discounted_revenue_for(merchant)
     invoice_items.joins(item: :merchant)
                  .where(merchants: {id: merchant})
-                 .sum { |invoice_item| invoice_item.discounted_revenue }
+      .sum { |invoice_item| invoice_item.discounted_revenue }.to_i
   end
 
   def total_invoice_revenue

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -49,8 +49,8 @@
 <% end %>
 
 <div id="revenue">
-  <h2>Total Revenue: $<%= @invoice.total_invoice_revenue.to_s.insert(-3,".") %> </h2>
+  <h2>Total Revenue: $<%= @invoice.total_revenue_for(params[:merchant_id]).to_s.insert(-3,".") %> </h2>
   <% unless @invoice.orders_that_can_be_discounted.empty? %>
-    <h2>Discounted Revenue: $<%= @invoice.total_discounted_revenue.to_s.insert(-3,".") %></h2>
+    <h2>Discounted Revenue: $<%= @invoice.discounted_revenue_for(params[:merchant_id]).to_s.insert(-3,".") %></h2>
   <% end %>
 </div>

--- a/spec/features/merchant/invoices/show_spec.rb
+++ b/spec/features/merchant/invoices/show_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe 'merchant invoice show page' do
       expect(page).to_not have_css("#item-#{@item_4.id}")
     end
 
-    it "displays the total revenue for all items on the invoice" do
-      expect(page).to have_content("Total Revenue: $48.00")
-      expect(page).to_not have_content("Total Revenue: $73.00")
+    it "displays the total revenue for items that belong to the merchant on the invoice" do
+      expect(page).to have_content("Total Revenue: $33.00")
+      expect(page).to_not have_content("Total Revenue: $48.00")
     end
 
     it 'displays a select box to change an invoice_item status' do
@@ -120,7 +120,7 @@ RSpec.describe 'merchant invoice show page' do
       end
     end
 
-    it 'displays the discounted revenue next to the total revenue' do
+    it 'displays the discounted revenue for the merchant next to the total revenue' do
       merchant = Merchant.create!(name: 'Brylan')
       merchant_2 = Merchant.create!(name: 'Chris')
 
@@ -141,14 +141,14 @@ RSpec.describe 'merchant invoice show page' do
 
       visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
       within '#revenue' do
-        expect(page).to have_content("Total Revenue: $53.00")
-        expect(page).to_not have_content("Total Revenue: $33.00")
+        expect(page).to have_content("Total Revenue: $33.00")
+        expect(page).to_not have_content("Total Revenue: $53.00")
         expect(page).to_not have_content("Total Revenue: $29.70")
-        expect(page).to have_content("Discounted Revenue: $49.70")
+        expect(page).to have_content("Discounted Revenue: $29.70")
       end
     end
 
-    it 'does not display discounted_revenue if no orders qualify for a discount' do
+    it 'does not display discounted_revenue for the merchant if no orders qualify for a discount' do
       merchant = Merchant.create!(name: 'Brylan')
       merchant_2 = Merchant.create!(name: 'Chris')
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Invoice do
       expect(@invoice_2.orders_that_can_be_discounted).to eq([])
     end
 
+    it '.discounted_revenue_for(merchant) returns the discounted revenue for items from a given merchant' do
+      @merchant_2.bulk_discounts.create!(name: 'buy 2 get 10% off', quantity_threshold: 2, discount_percent: 10)
+
+      expect(@invoice_1.discounted_revenue_for(@merchant)).to eq(2970)
+      expect(@invoice_1.discounted_revenue_for(@merchant_2)).to eq(1800)
+      expect(@invoice_1.discounted_revenue_for(@merchant)).to_not eq(@invoice_1.total_discounted_revenue)
+    end
+
     it '.total_discounted_revenue just returns total_revenue if no discounts are applied' do
       expect(@invoice_2.total_discounted_revenue).to eq(@invoice_2.total_invoice_revenue)
       expect(@invoice_2.total_discounted_revenue).to_not eq(1104)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Invoice do
       expect(Invoice.incomplete_invoices).to_not include(@invoice_3)
     end
 
+    it '.total_revenue_for(merchant) returns the sum of all item costs for a given merchant' do
+      expect(@invoice.total_revenue_for(@merchant)).to eq(3300)
+      expect(@invoice.total_revenue_for(@merchant_2)).to eq(2000)
+      expect(@invoice.total_revenue_for(@merchant)).to_not eq(5300)
+
+      expect(@invoice_2.total_revenue_for(@merchant)).to eq(2500)
+      expect(@invoice_2.total_revenue_for(@merchant_2)).to eq(0)
+    end
+
     it '.total_invoice_revenue returns the sum of all item costs' do
       merchant = Merchant.create!(name: 'Brylan')
       item_1 = merchant.items.create!(name: 'Bottle', unit_price: 10, description: 'H20')


### PR DESCRIPTION
Built out an edge case (to practice using Vim): 
- in the event that an invoice has multiple items from different merchants on it, I built 2 instance methods for `invoice.rb` that allow for a merchant's invoice show page to only display revenue for that merchant.
- the total invoice revenue across all items/merchants is displayed on the admin invoice show page.